### PR TITLE
New way of calculating ending time.

### DIFF
--- a/src/com/justbru00/epic/icetrack/listeners/IceTrackListener.java
+++ b/src/com/justbru00/epic/icetrack/listeners/IceTrackListener.java
@@ -223,4 +223,9 @@ public class IceTrackListener implements Listener {
 			}
 		}
 	}
+
+	@EventHandler
+	public void onStartTick(ServerTickStartEvent e) {
+		EpicIceTrack.currentTime = Instant.now();
+	}
 }

--- a/src/com/justbru00/epic/icetrack/main/EpicIceTrack.java
+++ b/src/com/justbru00/epic/icetrack/main/EpicIceTrack.java
@@ -26,6 +26,7 @@ public class EpicIceTrack extends JavaPlugin {
 	public static PluginFile dataFile = null;
 	public static boolean debug = true;
 	public static boolean enableLeaderboards = true;
+	public static Instant currentTime = Instant.now();
 
 	@Override
 	public void onDisable() {

--- a/src/com/justbru00/epic/icetrack/timer/PlayerTimer.java
+++ b/src/com/justbru00/epic/icetrack/timer/PlayerTimer.java
@@ -54,7 +54,7 @@ public class PlayerTimer {
 						PlayerData pd = PlayerData.getDataFor(p);
 						PlayerMapData pmd = pd.getMapData(playersInMaps.get(p.getUniqueId()).getInternalName());
 						
-						long mapTime = Duration.between(playerMapStartTime.get(p.getUniqueId()), Instant.now()).toMillis();
+						long mapTime = Duration.between(playerMapStartTime.get(p.getUniqueId()), EpicIceTrack.currentTime).toMillis();
 						
 						if (pmd.getBestTime() == -1) {
 							// The default value is still saved. This is currently their best time
@@ -129,7 +129,7 @@ public class PlayerTimer {
 		}
 		UUID boatUuid = online.getVehicle().getUniqueId();
 		
-		playerMapStartTime.put(p.getUniqueId(), Instant.now());
+		playerMapStartTime.put(p.getUniqueId(), EpicIceTrack.currentTime);
 		playersInMaps.put(p.getUniqueId(), m);
 		playersInMapsBoatUuids.put(p.getUniqueId(), boatUuid);
 		playersCheckpointScore.put(p.getUniqueId(), 0);

--- a/src/com/justbru00/epic/icetrack/timer/PlayerTimer.java
+++ b/src/com/justbru00/epic/icetrack/timer/PlayerTimer.java
@@ -191,8 +191,7 @@ public class PlayerTimer {
 	 * @param p
 	 * @param m
 	 */
-	public static void playerEndedMap(Player p, Map m) {		
-		Instant endTime = Instant.now();
+	public static void playerEndedMap(Player p, Map m) {
 		
 		if (!playersInMaps.containsKey(p.getUniqueId())) {
 			Messager.debug("&cFINISHED BEFORE STARTING");
@@ -247,7 +246,8 @@ public class PlayerTimer {
 		PlayerData pd = PlayerData.getDataFor(p);
 		PlayerMapData pmd = pd.getMapData(m.getInternalName());		
 		
-		long mapTime = Duration.between(playerMapStartTime.get(p.getUniqueId()), endTime).toMillis();
+		long mapTime = Duration.between(playerMapStartTime.get(p.getUniqueId()), EpicIceTrack.currentTime).toMillis();
+		mapTime = Math.round(mapTime/50) * 50;
 		
 		if (pmd.getBestTime() == -1) {
 			// The default value is still saved. This is the new best time.


### PR DESCRIPTION
Checking the timestamp at the beginning of the tick to remove tick duration variances in times. Also rounds to 50ms interval to avoid the 1ms difference that was present during testing.

Further question. I'm not sure how the current system ranks people on same best time. I believe oldest result should be first.